### PR TITLE
Add date and academic year inputs

### DIFF
--- a/api/parecer.js
+++ b/api/parecer.js
@@ -6,8 +6,8 @@ module.exports = async (req, res) => {
     return;
   }
 
-  const { nome, turma, escola, apoio } = req.body;
-  if (!nome || !turma || !escola || !apoio) {
+  const { nome, turma, escola, professora, turno, data, anoLetivo, apoio } = req.body;
+  if (!nome || !turma || !escola || !professora || !turno || !data || !anoLetivo || !apoio) {
     res.status(400).json({ error: 'Todos os campos são obrigatórios.' });
     return;
   }
@@ -20,7 +20,7 @@ module.exports = async (req, res) => {
 
   try {
     const prompt = `
-Você é um(a) professor(a) do ensino fundamental no Brasil. Escreva um parecer descritivo para o(a) aluno(a) ${nome}, da turma ${turma}, da escola ${escola}, conforme a LDB, considerando as seguintes observações: ${apoio}
+Você é um(a) professor(a) do ensino fundamental no Brasil. Escreva um parecer descritivo para o(a) aluno(a) ${nome}, da turma ${turma}, da escola ${escola}, turno ${turno}, professora regente ${professora}, no ano letivo de ${anoLetivo}. A data do parecer é ${data}. Considere as seguintes observações: ${apoio}
 O texto deve ser formal, objetivo, e adequado para relatórios escolares.
     `;
 

--- a/public/index.html
+++ b/public/index.html
@@ -23,12 +23,19 @@
         <label for="professora">Professora regente:</label>
         <input type="text" id="professora" name="professora" required placeholder="Nome da professora">
 
+
         <label for="turno">Turno:</label>
         <select id="turno" name="turno" required>
           <option value="">Selecione o turno</option>
           <option value="Manhã">Manhã</option>
           <option value="Tarde">Tarde</option>
         </select>
+
+        <label for="data">Data:</label>
+        <input type="date" id="data" name="data" required>
+
+        <label for="ano-letivo">Ano letivo:</label>
+        <input type="number" id="ano-letivo" name="ano-letivo" required placeholder="Ex: 2024">
 
         <label for="apoio">Observações/Questões principais:</label>
         <textarea id="apoio" name="apoio" rows="4" required placeholder="Ex: dificuldades, avanços, comportamento, etc."></textarea>

--- a/public/script.js
+++ b/public/script.js
@@ -6,6 +6,8 @@ document.getElementById('parecerform').addEventListener('submit', async function
   const escola = document.getElementById('escola').value.trim();
   const professora = document.getElementById('professora').value.trim();
   const turno = document.getElementById('turno').value;
+  const data = document.getElementById('data').value;
+  const anoLetivo = document.getElementById('ano-letivo').value.trim();
   const apoio = document.getElementById('apoio').value.trim();
   const resultadoDiv = document.getElementById('resultado');
 
@@ -15,7 +17,7 @@ document.getElementById('parecerform').addEventListener('submit', async function
     const response = await fetch('/api/parecer', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ nome, turma, escola, professora, turno, apoio })
+      body: JSON.stringify({ nome, turma, escola, professora, turno, data, anoLetivo, apoio })
     });
 
     const data = await response.json();

--- a/server.js
+++ b/server.js
@@ -15,15 +15,15 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 // Endpoint para gerar parecer
 app.post('/api/parecer', async (req, res) => {
-  const { nome, turma, escola, professora, turno, apoio } = req.body;
-  if (!nome || !turma || !escola || !professora || !turno || !apoio) {
+  const { nome, turma, escola, professora, turno, data, anoLetivo, apoio } = req.body;
+  if (!nome || !turma || !escola || !professora || !turno || !data || !anoLetivo || !apoio) {
     return res.status(400).json({ error: 'Todos os campos são obrigatórios.' });
   }
 
   try {
     // Montar prompt para a OpenAI
     const prompt = `
-Você é um(a) professor(a) do ensino fundamental no Brasil. Escreva um parecer descritivo detalhado para o(a) aluno(a) ${nome}, da turma ${turma}, da escola ${escola}, turno ${turno}, professora regente ${professora}, conforme a LDB, considerando as seguintes observações: ${apoio}
+Você é um(a) professor(a) do ensino fundamental no Brasil. Escreva um parecer descritivo detalhado para o(a) aluno(a) ${nome}, da turma ${turma}, da escola ${escola}, turno ${turno}, professora regente ${professora}, referente ao ano letivo de ${anoLetivo}. A data do parecer é ${data}. Considere as seguintes observações: ${apoio}
 
 Siga rigorosamente o modelo abaixo, que é um exemplo real de parecer feito por uma professora. Estruture o texto conforme os tópicos do exemplo, utilize linguagem formal, detalhada, e inclua recomendações à família e sugestões de intervenção, sempre que possível. Personalize o texto conforme as informações fornecidas.
 
@@ -48,7 +48,7 @@ Sabemos e reconhecemos o empenho, o carinho e a dedicação da família no acomp
 
 --- FIM DO EXEMPLO ---
 
-Siga o padrão acima, adaptando para o(a) aluno(a) ${nome}, turma ${turma}, escola ${escola}, e considerando as observações: ${apoio}. O texto deve ser formal, detalhado, estruturado e incluir recomendações à família. Continue até o final do parecer, sem cortar o texto.
+Siga o padrão acima, adaptando para o(a) aluno(a) ${nome}, turma ${turma}, escola ${escola}, ano letivo ${anoLetivo} e data ${data}, considerando as observações: ${apoio}. O texto deve ser formal, detalhado, estruturado e incluir recomendações à família. Continue até o final do parecer, sem cortar o texto.
     `;
 
     const response = await axios.post(


### PR DESCRIPTION
## Summary
- add new date and academic year fields to the form
- send new fields from frontend to backend
- handle the new fields in both Express server and serverless function

## Testing
- `npm install`
- `npm start` *(fails: OPENAI_API_KEY undefined but server started)*

------
https://chatgpt.com/codex/tasks/task_e_685b2364819483338976679131dc7968