### PR TITLE
Enable CORS and add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=coloque_sua_chave_aqui

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.6.0",
+        "cors": "^2.8.5",
         "dotenv": "^16.0.0",
         "express": "^4.18.2"
       }
@@ -158,6 +159,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -637,6 +651,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "axios": "^1.6.0",
     "dotenv": "^16.0.0",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,14 +1,20 @@
 require('dotenv').config();
-console.log('OPENAI_API_KEY:', process.env.OPENAI_API_KEY);
 const express = require('express');
 const axios = require('axios');
 const path = require('path');
+const cors = require('cors');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+if (!process.env.OPENAI_API_KEY) {
+  console.warn('Aviso: OPENAI_API_KEY não configurada. O endpoint /api/parecer retornará erro.');
+}
+
 // Middleware para ler JSON
 app.use(express.json());
+// Habilitar CORS para permitir requisições de outras origens
+app.use(cors());
 
 // Servir arquivos estáticos do frontend
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
## Summary
- add CORS support to allow requests from other origins
- add warning when `OPENAI_API_KEY` is not set
- provide `.env.example`
- include cors dependency

## Testing
- `npm install`
- `npm start` *(fails: connect to api.openai.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b255f124883339ff8dfb5ed82050d