### PR TITLE
Improve connection handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=coloque_sua_chave_aqui

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Gere pareceres descritivos para alunos conforme a LDB, usando a API do ChatGPT/O
    npm start
    ```
    O sistema estará disponível em [http://localhost:3000](http://localhost:3000).
+    Não abra o arquivo `index.html` diretamente, utilize essa URL para garantir
+    que as requisições ao backend funcionem corretamente.
 
 5. **Acesse pelo navegador:**
     Preencha os dados do aluno e as observações.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.6.0",
+        "cors": "^2.8.5",
         "dotenv": "^16.0.0",
         "express": "^4.18.2"
       }
@@ -158,6 +159,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -637,6 +651,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "axios": "^1.6.0",
     "dotenv": "^16.0.0",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
   }
 }

--- a/public/script.js
+++ b/public/script.js
@@ -1,3 +1,9 @@
+// Determina a URL base para a API. Quando o HTML é aberto via file://,
+// window.location.origin é "null" e precisamos apontar para o servidor local.
+const API_BASE = window.location.origin === 'null'
+  ? 'http://localhost:3000'
+  : window.location.origin;
+
 document.getElementById('parecerform').addEventListener('submit', async function (e) {
   e.preventDefault();
 
@@ -14,7 +20,7 @@ document.getElementById('parecerform').addEventListener('submit', async function
   resultadoDiv.innerHTML = '<p>Gerando parecer, aguarde...</p>';
 
   try {
-    const response = await fetch('/api/parecer', {
+    const response = await fetch(`${API_BASE}/api/parecer`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ nome, turma, escola, professora, turno, data, anoLetivo, apoio })

--- a/server.js
+++ b/server.js
@@ -1,14 +1,20 @@
 require('dotenv').config();
-console.log('OPENAI_API_KEY:', process.env.OPENAI_API_KEY);
 const express = require('express');
 const axios = require('axios');
 const path = require('path');
+const cors = require('cors');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+if (!process.env.OPENAI_API_KEY) {
+  console.warn('Aviso: OPENAI_API_KEY não configurada. O endpoint /api/parecer retornará erro.');
+}
+
 // Middleware para ler JSON
 app.use(express.json());
+// Habilitar CORS para permitir requisições de outras origens
+app.use(cors());
 
 // Servir arquivos estáticos do frontend
 app.use(express.static(path.join(__dirname, 'public')));
@@ -73,6 +79,7 @@ Siga o padrão acima, adaptando para o(a) aluno(a) ${nome}, turma ${turma}, esco
     const parecer = response.data.choices[0].message.content.trim();
     res.json({ parecer });
   } catch (error) {
+    console.error('Erro ao chamar a OpenAI:', error.message);
     res.status(500).json({ error: 'Erro ao gerar parecer. Verifique sua chave da OpenAI e tente novamente.' });
   }
 });


### PR DESCRIPTION
## Summary
- warn users not to open `index.html` directly
- let the frontend determine the correct base URL
- log OpenAI request errors in the backend

## Testing
- `npm install`
- `npm start` *(fails: connect to api.openai.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b255f124883339ff8dfb5ed82050d